### PR TITLE
Gulp jscs fix

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -156,7 +156,8 @@ gulp.task('lint', function() {
 // =======================================================================
 gulp.task('checkstyle', function() {
     return gulp.src(filePath.lint.src)
-    .pipe(jscs());
+    .pipe(jscs())
+    .on('error', handleError);
 });
 
 
@@ -348,6 +349,7 @@ gulp.task('watch', function() {
     gulp.watch(filePath.vendorJS.src, ['vendorJS']);
     gulp.watch(filePath.vendorCSS.src, ['vendorCSS']);
     gulp.watch(filePath.copyIndex.watch, ['copyIndex']);
+    gulp.watch(filePath.lint.src, ['checkstyle']);
     console.log('Watching...');
 });
 


### PR DESCRIPTION
**This was the previous workflow:**

1. Execute `gulp`.
2. `checkstyle` task throws style errors that are printed on the console.
3. If there are style errors, Gulp exits.

**This is the workflow after the changes:**

1. Execute `gulp`.
2. `checkstyle` task prints style errors on the console.
3. Gulp continues with other tasks.
4. When you change your files, `checkstyle` is executed again.

In my opinion, this is an improvement. What do you think?