### PR TITLE
Istanbul ignores libs

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,7 @@
 // Karma configuration
 
+var istanbul = require('browserify-istanbul');
+
 'use strict';
 
 module.exports = function (config) {
@@ -33,7 +35,9 @@ module.exports = function (config) {
 
         browserify: {
             debug: true,
-            transform: ['debowerify', 'html2js-browserify', 'browserify-istanbul'],
+            transform: ['debowerify', 'html2js-browserify', istanbul({
+              'ignore': ['**/*.spec.js', '**/libs/**']
+            })],
 
             // don't forget to register the extensions
             extensions: ['.js']

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -36,7 +36,7 @@ module.exports = function (config) {
         browserify: {
             debug: true,
             transform: ['debowerify', 'html2js-browserify', istanbul({
-              'ignore': ['**/*.spec.js', '**/libs/**']
+                'ignore': ['**/*.spec.js', '**/libs/**']
             })],
 
             // don't forget to register the extensions


### PR DESCRIPTION
As has been discussed in issue #21, we can use browserify-istanbul with karma-coverage to provide a test coverage report. This code instructs Istanbul to not consider *spec.js and /libs/** when it creates the report.