### PR TITLE
use strict gulp warning fixed

### DIFF
--- a/app/common/common.js
+++ b/app/common/common.js
@@ -1,3 +1,4 @@
+'use strict';
 window.jQuery = window.$ = require('jquery');
 window._ = require('lodash');
 


### PR DESCRIPTION
Solve these gulp warnings
app/common/common.js
  line 1   col 45  Missing "use strict" statement.
  line 2   col 29  Missing "use strict" statement.
  line 4   col 29  Missing "use strict" statement.
  line 5   col 29  Missing "use strict" statement.
  line 6   col 27  Missing "use strict" statement.
  line 7   col 27  Missing "use strict" statement.
  line 8   col 28  Missing "use strict" statement.
  line 9   col 28  Missing "use strict" statement.
  line 10  col 26  Missing "use strict" statement.
  line 11  col 18  Missing "use strict" statement.
  line 12  col 23  Missing "use strict" statement.
  line 29  col 7   Missing "use strict" statement.

  ✖  12 errors  ⚠  0 warnings
